### PR TITLE
build: allow any v0 lark version after 0.11.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 packages = [{ include = "larkjs" }]
 
 [tool.poetry.dependencies]
-lark-parser = "^0.11.1"
+lark = "^0, >=0.11.1"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
Closes #8.

I know you're running two equivalent packages, `lark` and `lark-parser`, but the suggested name over in [lark-parser/lark](https://github.com/lark-parser/lark#install-lark) is just lark, so I changed that here too.

