### PR TITLE
fix: compiler errors

### DIFF
--- a/larkjs/lark.js
+++ b/larkjs/lark.js
@@ -7,7 +7,7 @@
 /**
 	This is the main entrypoint into the generated Lark parser.
 
-  @param {object} options An object with the following optional properties: 
+  @param {object} options An object with the following optional properties:
 
 	  - transformer: an object of {rule: callback}, or an instance of Transformer
 	  - propagate_positions (bool): should all tree nodes calculate line/column info?
@@ -161,7 +161,7 @@ function range(start, end) {
     end = start;
     start = 0;
   }
-  res = [];
+  const res = [];
   for (let i = start; i < end; i++) res.push(i);
   return res;
 }
@@ -397,7 +397,7 @@ class LexError extends LarkError {
     - ``UnexpectedEOF``: The parser expected a token, but the input ended
 
     After catching one of these exceptions, you may call the following helper methods to create a nicer error message.
-    
+
 */
 
 class UnexpectedInput extends LarkError {
@@ -410,7 +410,7 @@ class UnexpectedInput extends LarkError {
         Note:
             The parser doesn't hold a copy of the text it has to parse,
             so you have to provide it again
-        
+
   */
   get_context(text, span = 40) {
     let after, before;
@@ -450,7 +450,7 @@ class UnexpectedInput extends LarkError {
             parse_fn: parse function (usually ``lark_instance.parse``)
             examples: dictionary of ``{'example_string': value}``.
             use_accepts: Recommended to keep this as ``use_accepts=True``.
-        
+
   */
   match_examples(
     parse_fn,
@@ -511,7 +511,7 @@ class UnexpectedInput extends LarkError {
 
 /**
   An exception that is raised by the parser, when the input ends while it still expects a token.
-    
+
 */
 
 class UnexpectedEOF extends UnexpectedInput {
@@ -529,9 +529,9 @@ class UnexpectedEOF extends UnexpectedInput {
 }
 
 /**
-  An exception that is raised by the lexer, when it cannot match the next 
+  An exception that is raised by the lexer, when it cannot match the next
     string of characters to any of its terminals.
-    
+
 */
 
 class UnexpectedCharacters extends UnexpectedInput {
@@ -576,7 +576,7 @@ class UnexpectedCharacters extends UnexpectedInput {
                             and can be used for debugging and error handling.
 
     Note: These parameters are available as attributes of the instance.
-    
+
 */
 
 class UnexpectedToken extends UnexpectedInput {
@@ -626,7 +626,7 @@ class UnexpectedToken extends UnexpectedInput {
         orig_exc: the exception that cause it to fail
 
     Note: These parameters are available as attributes
-    
+
 */
 
 class VisitError extends LarkError {
@@ -694,7 +694,7 @@ function _deserialize(data, namespace, memo) {
         __serialize_fields__ (List[str]): Fields (aka attributes) to serialize.
         __serialize_namespace__ (list): List of classes that deserialization is allowed to instantiate.
                                         Should include all field types that aren't builtin types.
-    
+
 */
 
 class Serialize {
@@ -771,7 +771,7 @@ class Meta {
         children: List of matched sub-rules and terminals
         meta: Line & Column numbers (if ``propagate_positions`` is enabled).
             meta attributes: line, column, start_pos, end_line, end_column, end_pos
-    
+
 */
 
 class Tree {
@@ -824,7 +824,7 @@ class Tree {
     Returns an indented string representation of the tree.
 
         Great for debugging.
-        
+
   */
   pretty(indent_str = "  ") {
     return this._pretty(0, indent_str).join("");
@@ -851,7 +851,7 @@ class Tree {
     Depth-first iteration.
 
         Iterates over all the subtrees, never returning to the same node twice (Lark's parse-tree is actually a DAG).
-        
+
   */
   iter_subtrees() {
     let queue = [this];
@@ -892,7 +892,7 @@ class Tree {
 
         Example:
             >>> all_tokens = tree.scan_values(lambda v: isinstance(v, Token))
-        
+
   */
   *scan_values(pred) {
     for (const c of this.children) {
@@ -912,7 +912,7 @@ class Tree {
     Breadth-first iteration.
 
         Iterates over all the subtrees, return nodes in order like pretty() does.
-        
+
   */
   *iter_subtrees_topdown() {
     let node;
@@ -945,7 +945,7 @@ class Tree {
 //
 
 /**
-  Transformers work bottom-up (or depth-first), starting with visiting the leaves and working 
+  Transformers work bottom-up (or depth-first), starting with visiting the leaves and working
     their way up until ending at the root of the tree.
 
     For each node visited, the transformer will call the appropriate method (callbacks), according to the
@@ -956,7 +956,7 @@ class Tree {
 
     If the transformer cannot find a method with the right name, it will instead call ``__default__``, which by
     default creates a copy of the node.
-    
+
     To discard a node, return Discard (``lark.visitors.Discard``).
 
     ``Transformer`` can do anything ``Visitor`` can do, but because it reconstructs the tree,
@@ -975,7 +975,7 @@ class Tree {
                                        Setting this to ``False`` is slightly faster. Defaults to ``True``.
                                        (For processing ignored tokens, use the ``lexer_callbacks`` options)
 
-    
+
 */
 
 class Transformer extends _Decoratable {
@@ -1076,7 +1076,7 @@ class Transformer extends _Decoratable {
     Default function that is called if there is no attribute matching ``data``
 
         Can be overridden. Defaults to creating a new copy of the tree node (i.e. ``return Tree(data, children, meta)``)
-        
+
   */
   __default__(data, children, meta) {
     return new Tree(data, children, meta);
@@ -1086,7 +1086,7 @@ class Transformer extends _Decoratable {
     Default function that is called if there is no attribute matching ``token.type``
 
         Can be overridden. Defaults to returning the token as-is.
-        
+
   */
   __default_token__(token) {
     return token;
@@ -1097,7 +1097,7 @@ class Transformer extends _Decoratable {
   Same as Transformer, but non-recursive, and changes the tree in-place instead of returning new instances
 
     Useful for huge trees. Conservative in memory.
-    
+
 */
 
 class Transformer_InPlace extends Transformer {
@@ -1121,7 +1121,7 @@ class Transformer_InPlace extends Transformer {
     Like Transformer, it doesn't change the original tree.
 
     Useful for huge trees.
-    
+
 */
 
 class Transformer_NonRecursive extends Transformer {
@@ -1196,7 +1196,7 @@ class VisitorBase {
     Default function that is called if there is no attribute matching ``tree.data``
 
         Can be overridden. Defaults to doing nothing.
-        
+
   */
   __default__(tree) {
     return tree;
@@ -1211,7 +1211,7 @@ class VisitorBase {
   Tree visitor, non-recursive (can handle huge trees).
 
     Visiting a node calls its methods (provided by the user via inheritance) according to ``tree.data``
-    
+
 */
 
 class Visitor extends VisitorBase {
@@ -1244,7 +1244,7 @@ class Visitor extends VisitorBase {
     Visiting a node calls its methods (provided by the user via inheritance) according to ``tree.data``
 
     Slightly faster than the non-recursive version.
-    
+
 */
 
 class Visitor_Recursive extends VisitorBase {
@@ -1287,7 +1287,7 @@ class Visitor_Recursive extends VisitorBase {
     Unlike ``Transformer`` and ``Visitor``, the Interpreter doesn't automatically visit its sub-branches.
     The user has to explicitly call ``visit``, ``visit_children``, or use the ``@visit_children_decor``.
     This allows the user to implement branching and loops.
-    
+
 */
 
 class Interpreter extends _Decoratable {
@@ -1411,11 +1411,11 @@ class RuleOptions extends Serialize {
 }
 
 /**
-  
+
         origin : a symbol
         expansion : a list of symbols
         order : index of this expansion amongst all rules of the same name
-    
+
 */
 
 class Rule extends Serialize {
@@ -1591,7 +1591,7 @@ class TerminalDef extends Serialize {
             if the token is a single character with a column value of 4,
             end_column will be 5.
         end_pos: the index where the token ends (basically ``start_pos + len(token)``)
-    
+
 */
 
 class Token {
@@ -1678,7 +1678,7 @@ class LineCounter {
     Consume a token and calculate the new line & column.
 
         As an optional optimization, set test_newline=False if token doesn't contain a newline.
-        
+
   */
   feed(token, test_newline = true) {
     let newlines;
@@ -1774,7 +1774,7 @@ function _create_unless(terminals, g_regex_flags, re_, use_bytes) {
         - anything but ([^...])
         - any-char (.) when the flag (?s) exists
         - spaces (\s)
-    
+
   */
 function _regexp_has_newline(r) {
   return (
@@ -1789,7 +1789,7 @@ function _regexp_has_newline(r) {
 /**
   Represents the current state of the lexer as it scans the text
     (Lexer objects are only instanciated per grammar, not per text)
-    
+
 */
 
 class LexerState {
@@ -1814,7 +1814,7 @@ class LexerState {
 
 /**
   A thread that ties a lexer instance and a lexer state, to be used by the parser
-    
+
 */
 
 class LexerThread {
@@ -1837,7 +1837,7 @@ class LexerThread {
 
     Method Signatures:
         lex(self, lexer_state, parser_state) -> Iterator[Token]
-    
+
 */
 
 class Lexer extends ABC {
@@ -2439,7 +2439,7 @@ function maybe_create_child_filter(
 
 
 /**
-  
+
     Propagate ambiguous intermediate nodes and their derivations up to the
     current rule.
 
@@ -2477,7 +2477,7 @@ function maybe_create_child_filter(
       ...
 
     propagating up any nested '_iambig' nodes along the way.
-    
+
 */
 
 function inplace_transformer(func) {
@@ -2854,7 +2854,7 @@ class _Parser {
   InteractiveParser gives you advanced control over parsing and error handling when parsing with LALR.
 
     For a simpler interface, see the ``on_error`` argument to ``Lark.parse()``.
-    
+
 */
 
 class InteractiveParser {
@@ -2869,7 +2869,7 @@ class InteractiveParser {
     Feed the parser with a token, and advance it to the next state, as if it received it from the lexer.
 
         Note that ``token`` has to be an instance of ``Token``.
-        
+
   */
   feed_token(token) {
     return this.parser_state.feed_token(token, token.type === "$END");
@@ -2881,8 +2881,8 @@ class InteractiveParser {
 
         Returns an iterator of the tokens it encounters.
 
-        When the parse is over, the resulting tree can be found in ``InteractiveParser.result``. 
-        
+        When the parse is over, the resulting tree can be found in ``InteractiveParser.result``.
+
   */
   *iter_parse() {
     for (const token of this.lexer_thread.lex(this.parser_state)) {
@@ -2893,9 +2893,9 @@ class InteractiveParser {
 
   /**
     Try to feed the rest of the lexer state into the interactive parser.
-        
+
         Note that this modifies the instance in place and does not feed an '$END' Token
-        
+
   */
   exhaust_lexer() {
     return [...this.iter_parse()];
@@ -2958,7 +2958,7 @@ class InteractiveParser {
         Only returns token types that are accepted by the current state.
 
         Updated by ``feed_token()``.
-        
+
   */
   choices() {
     return this.parser_state.parse_conf.parse_table.states[
@@ -2976,7 +2976,7 @@ class InteractiveParser {
       if (isupper(t)) {
         // is terminal?
         new_cursor = copy(this);
-        exc = null;
+        let exc = null;
         try {
           new_cursor.feed_token(new Token(t, ""));
         } catch (e) {
@@ -3007,7 +3007,7 @@ class InteractiveParser {
 /**
   Same as ``InteractiveParser``, but operations create a new instance instead
     of changing it in-place.
-    
+
 */
 
 class ImmutableInteractiveParser extends InteractiveParser {
@@ -3103,13 +3103,12 @@ class ParseTable {
 class IntParseTable extends ParseTable {
   static from_ParseTable(parse_table) {
     const cls = this;
-    let la;
     let enum_ = [...parse_table.states];
     let state_to_idx = Object.fromEntries(
       enumerate(enum_).map(([i, s]) => [s, i])
     );
     let int_states = {};
-    for (const [s, la] of dict_items(parse_table.states)) {
+    for (let [s, la] of dict_items(parse_table.states)) {
       la = Object.fromEntries(
         dict_items(la).map(([k, v]) => [
           k,
@@ -3392,7 +3391,7 @@ class PostLex extends ABC {
 /**
   Specifies the options for Lark
 
-    
+
 */
 
 class LarkOptions extends Serialize {
@@ -3571,7 +3570,7 @@ var _VALID_AMBIGUITY_OPTIONS = ["auto", "resolve", "explicit", "forest"];
     Example:
         >>> Lark(r'''start: "foo" ''')
         Lark(...)
-    
+
 */
 
 class Lark extends Serialize {
@@ -3614,13 +3613,13 @@ class Lark extends Serialize {
     Saves the instance into the given file object
 
         Useful for caching and multiprocessing.
-        
+
   */
   /**
     Loads an instance from the given file object
 
         Useful for caching and multiprocessing.
-        
+
   */
   _deserialize_lexer_conf(data, memo, options) {
     let lexer_conf = LexerConf.deserialize(data["lexer_conf"], memo);
@@ -3703,7 +3702,7 @@ class Lark extends Serialize {
             >>> Lark.open("grammar_file.lark", rel_to=__file__, parser="lalr")
             Lark(...)
 
-        
+
   */
   /**
     Create an instance of Lark with the grammar loaded from within the package `package`.
@@ -3714,7 +3713,7 @@ class Lark extends Serialize {
         Example:
 
             Lark.open_from_package(__name__, "example.lark", ("grammars",), parser=...)
-        
+
   */
   repr() {
     return format(
@@ -3731,7 +3730,7 @@ class Lark extends Serialize {
         When dont_ignore=True, the lexer will return all tokens, even those marked for %ignore.
 
         :raises UnexpectedCharacters: In case the lexer cannot find a suitable match.
-        
+
   */
   lex(text, dont_ignore = false) {
     let lexer;
@@ -3767,7 +3766,7 @@ class Lark extends Serialize {
             A new InteractiveParser instance.
 
         See Also: ``Lark.parse()``
-        
+
   */
   parse_interactive(text = null, start = null) {
     return this.parser.parse_interactive({
@@ -3793,7 +3792,7 @@ class Lark extends Serialize {
                 ``UnexpectedCharacters``, ``UnexpectedToken``, or ``UnexpectedEOF``.
                 For convenience, these sub-exceptions also inherit from ``ParserError`` and ``LexerError``.
 
-        
+
   */
   parse(text, start = null, on_error = null) {
     return this.parser.parse(text, start, on_error);


### PR DESCRIPTION
Fix the compiler errors addressed in https://github.com/lark-parser/Lark.js/issues/28. 
Other changes are to remove the extra spaces which are made automatically by IDE.