### PR TITLE
Fix UnexpectedInput.get_context() errors

### DIFF
--- a/larkjs/lark.js
+++ b/larkjs/lark.js
@@ -413,25 +413,13 @@ class UnexpectedInput extends LarkError {
 
   */
   get_context(text, span = 40) {
-    let after, before;
-    let pos = this.pos_in_stream;
-    let start = max(pos - span, 0);
-    let end = pos + span;
-    if (!(text instanceof bytes)) {
-      before = last_item(rsplit(text.slice(start, pos), "\n", 1));
-      after = text.slice(pos, end).split("\n", 1)[0];
-      return before + after + "\n" + " " * before.expandtabs().length + "^\n";
-    } else {
-      before = last_item(rsplit(text.slice(start, pos), "\n", 1));
-      after = text.slice(pos, end).split("\n", 1)[0];
-      return (
-        before +
-        after +
-        "\n" +
-        " " * before.expandtabs().length +
-        "^\n"
-      ).decode("ascii", "backslashreplace");
-    }
+    const pos = this.pos_in_stream;
+    const start = Math.max(pos - span, 0);
+    const end = pos + span;
+    const before = last_item(rsplit(text.slice(start, pos), "\n", 1));
+    const after = text.slice(pos, end).split("\n", 1)[0];
+
+    return before + after + "\n" + " ".repeat(before.length) + "^\n";
   }
 
   /**


### PR DESCRIPTION
I tried to call `get_context()` like this:

```typescript
try {
  const result = parser.parse(equation);
  console.log(result.pretty());
} catch (e) {
  console.log("There was an error in the following line");
  console.log(e.get_context(equation));
}
```

But I got several errors indicating that some symbols are not defined (I execute Lark.js through node v16.18.1)

- max is not defined
- bytes is not defined
- expandtabs is not defined

Correct me if I am wrong but I suspect that this code is autogenerated from Python where those symbols are defined. I rewrote it so it can be executed in my environment. I took the following decisions:
- I assume that text is a string
- I do not try to expand tabs