### PR TITLE
Fix ParserInteractive.accepts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Node
+node_modules

--- a/larkjs/lark.js
+++ b/larkjs/lark.js
@@ -2960,7 +2960,9 @@ class InteractiveParser {
   accepts() {
     let new_cursor;
     let accepts = new Set();
-    for (const t of this.choices()) {
+    const choices = this.choices();
+    for (const key in choices) {
+      const t = choices[key];
       if (isupper(t)) {
         // is terminal?
         new_cursor = copy(this);
@@ -3757,10 +3759,7 @@ class Lark extends Serialize {
 
   */
   parse_interactive(text = null, start = null) {
-    return this.parser.parse_interactive({
-      unknown_param_0: text,
-      start: start,
-    });
+    return this.parser.parse_interactive(text, start);
   }
 
   /**

--- a/test/test.js
+++ b/test/test.js
@@ -1,15 +1,19 @@
 const {TestTrees} = require("./test_trees.js");
+const {TestInteractive} = require("./test_interactive.js");
 
 function run_test_class(cls) {
-	describe(cls.constructor.name, function() {
+  describe(cls.constructor.name, function() {
 
-		let test = new cls();
-		test.setUp();
-		let test_names = Object.getOwnPropertyNames(cls.prototype).filter((prop) => prop.startsWith("test_"))
-		for (const name of test_names) {
-			it(name, () => {test[name]()})
-		}
-	});
+    let test = new cls();
+    if (test.setUp) {
+      test.setUp();
+    }
+    let test_names = Object.getOwnPropertyNames(cls.prototype).filter((prop) => prop.startsWith("test_"))
+    for (const name of test_names) {
+      it(name, () => {test[name]()})
+    }
+  });
 }
 
 run_test_class(TestTrees);
+run_test_class(TestInteractive);

--- a/test/test_interactive.js
+++ b/test/test_interactive.js
@@ -1,0 +1,52 @@
+const _ = require("lodash");
+const lark = require("../larkjs/lark.js");
+const assert = require('assert');
+
+const {
+  InteractiveParser,
+} = lark;
+
+//
+// Test Interactive
+//
+
+class TestCase {
+  assertOk(a) {
+    assert(!!a); // assert that the value is truthy
+  }
+}
+
+class TestInteractive extends TestCase {
+  test_it_parses_interactively() {
+    const mockParser = {};
+    const mockParserState = {
+      position: 30,
+      parse_conf: {
+        parse_table: {
+          states: {
+            30: {
+
+              "ESCAPED_STRING": [
+                {
+                  "name": "Shift"
+                },
+                8
+              ],
+              "string": [
+                {
+                  "name": "Shift"
+                },
+                7
+              ],
+            },
+          }
+        }
+      }};
+    const mockLexerThread = {};
+    const interactiveParser = new InteractiveParser(mockParser, mockParserState, mockLexerThread);
+    this.assertOk(interactiveParser.accepts());
+  }
+}
+
+module.exports = { TestInteractive };
+


### PR DESCRIPTION
- [Fixes bug with `InteractiveParser.accepts()`](https://github.com/lark-parser/Lark.js/issues/39)
- Adds `node_modules` to `.gitignore` (node modules should not be added to the repo)